### PR TITLE
Update `ember-cli-htmlbars` to 1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "0.7.9"
+    "ember-cli-htmlbars": "1.0.8"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
This gets rid of a deprecation on ember 2.6:
```
DEPRECATION: Overriding init without calling this._super is deprecated.
Please call `this._super.init && this._super.init.apply(this, arguments);`
addon: `ember-cli-htmlbars`
    at Function.Addon.lookup
```